### PR TITLE
Add env-based CORS origin control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# CBPump
+
+This repository contains the backend and frontend code for the CBMo4ers crypto dashboard.
+
+## Backend Configuration
+
+The backend can be configured through environment variables. A new variable `CORS_ALLOWED_ORIGINS` has been added to specify which origins are allowed to access the API and WebSocket server.
+
+Set `CORS_ALLOWED_ORIGINS` to a comma-separated list of allowed origins. Use `*` to allow any origin (default).
+
+```bash
+# Allow requests from https://example.com and https://foo.bar
+export CORS_ALLOWED_ORIGINS="https://example.com,https://foo.bar"
+```
+
+## Development
+
+See `DOCKER.md` for container details and `docker-compose.yml` for available services.

--- a/backend/app.py
+++ b/backend/app.py
@@ -20,8 +20,16 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 # Flask App Setup
 app = Flask(__name__)
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'crypto-dashboard-secret')
-socketio = SocketIO(app, cors_allowed_origins="*")
-CORS(app)
+
+# Configure allowed CORS origins from environment
+cors_env = os.environ.get('CORS_ALLOWED_ORIGINS', '*')
+if cors_env == '*':
+    cors_origins = '*'
+else:
+    cors_origins = [origin.strip() for origin in cors_env.split(',') if origin.strip()]
+
+socketio = SocketIO(app, cors_allowed_origins=cors_origins)
+CORS(app, origins=cors_origins)
 
 # Dynamic Configuration with Environment Variables and Defaults
 CONFIG = {


### PR DESCRIPTION
## Summary
- read allowed origins from `CORS_ALLOWED_ORIGINS`
- document CORS setting in README

## Testing
- `python3 -m unittest discover -s backend` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68511640a4cc832985d0531d7e0af5e2