### PR TITLE
Refactor 3‑minute gainers/losers tables

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -591,6 +591,21 @@ def format_banner_data(banner_data):
         for coin in banner_data
     ]
 
+def format_table_data(coins):
+    """Format gainers/losers table data using the same style as 1-minute data."""
+    table_data = []
+    for i, coin in enumerate(coins[:20]):
+        table_data.append({
+            "rank": i + 1,
+            "symbol": coin["symbol"],
+            "current": coin["current"],
+            "initial_3min": coin["initial_3min"],
+            "gain": coin["gain"],
+            "interval_minutes": coin.get("interval_minutes", 3),
+        })
+
+    return table_data
+
 # =============================================================================
 # MAIN DATA PROCESSING FUNCTION
 # =============================================================================
@@ -1087,23 +1102,9 @@ def get_gainers_table():
         data = get_crypto_data()
         if not data:
             return jsonify({"error": "No data available"}), 503
-            
         gainers = data.get('gainers', [])
-        
-        # Enhanced formatting specifically for gainers table
-        gainers_table_data = []
-        for i, coin in enumerate(gainers[:20]):  # Top 20 gainers
-            gainers_table_data.append({
-                "rank": i + 1,
-                "symbol": coin["symbol"],
-                "current_price": coin["current"],  # Use correct field name
-                "price_change_percentage_3min": coin["gain"],  # Use correct field name
-                "initial_price_3min": coin["initial_3min"],  # Use correct field name
-                "actual_interval_minutes": coin.get("interval_minutes", 3),  # Use correct field name
-                "momentum": "strong" if coin["gain"] > 5 else "moderate",
-                "alert_level": "high" if coin["gain"] > 10 else "normal"
-            })
-        
+        gainers_table_data = format_table_data(gainers)
+
         return jsonify({
             "component": "gainers_table",
             "data": gainers_table_data,
@@ -1124,23 +1125,9 @@ def get_losers_table():
         data = get_crypto_data()
         if not data:
             return jsonify({"error": "No data available"}), 503
-            
         losers = data.get('losers', [])
-        
-        # Enhanced formatting specifically for losers table
-        losers_table_data = []
-        for i, coin in enumerate(losers[:20]):  # Top 20 losers
-            losers_table_data.append({
-                "rank": i + 1,
-                "symbol": coin["symbol"],
-                "current_price": coin["current"],  # Use correct field name
-                "price_change_percentage_3min": coin["gain"],  # Use correct field name (negative for losers)
-                "initial_price_3min": coin["initial_3min"],  # Use correct field name
-                "actual_interval_minutes": coin.get("interval_minutes", 3),  # Use correct field name
-                "momentum": "strong" if coin["gain"] < -5 else "moderate",
-                "alert_level": "high" if coin["gain"] < -10 else "normal"
-            })
-        
+        losers_table_data = format_table_data(losers)
+
         return jsonify({
             "component": "losers_table",
             "data": losers_table_data,

--- a/backend/test_app.py
+++ b/backend/test_app.py
@@ -4,7 +4,13 @@ import types
 import unittest
 
 # Import missing functions from app.py
-from app import calculate_interval_changes, format_crypto_data, process_product_data, price_history
+from app import (
+    calculate_interval_changes,
+    format_crypto_data,
+    format_table_data,
+    process_product_data,
+    price_history,
+)
 
 # Update mocking strategy
 import flask
@@ -70,6 +76,32 @@ class TestFormatCryptoData(unittest.TestCase):
         'interval_minutes': 3.0,
     }
 ]
+        self.assertEqual(result, expected)
+
+
+class TestFormatTableData(unittest.TestCase):
+    def test_format_table_data_matches_style(self):
+        coins = [
+            {
+                'symbol': 'BTC-USD',
+                'current': 110.0,
+                'initial_3min': 100.0,
+                'gain': 10.0,
+                'interval_minutes': 3.0,
+            }
+        ]
+
+        result = format_table_data(coins)
+        expected = [
+            {
+                'rank': 1,
+                'symbol': 'BTC-USD',
+                'current': 110.0,
+                'initial_3min': 100.0,
+                'gain': 10.0,
+                'interval_minutes': 3.0,
+            }
+        ]
         self.assertEqual(result, expected)
 
 


### PR DESCRIPTION
## Summary
- remove momentum and alert metadata from `format_table_data` to match 1‑minute output shape
- update table endpoints and add regression test for streamlined formatter

## Testing
- `npm run lint` *(fails: ENOENT: no such file or directory, open '/workspace/CBPump/package.json')*
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/CBPump/package.json')*
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b9ed38e2c8329b48275eb61fce22b

## Summary by Sourcery

Streamline 3-minute gainers/losers table formatting by extracting shared logic into a new helper, aligning output with the 1-minute data shape, and adding a regression test for the formatter

Enhancements:
- Extract a format_table_data helper to unify gainers and losers table formatting
- Remove momentum and alert_level fields to match the 1-minute output structure
- Refactor get_gainers_table and get_losers_table endpoints to use the new formatter

Tests:
- Add a regression unit test for format_table_data to validate table output shape